### PR TITLE
Return false on missing key in Get()

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -36,6 +36,7 @@ type Options struct {
 // Session stores the values and optional configuration for a session.
 type Session interface {
 	// Get returns the session value associated to the given key.
+	// If no key is set; false is returned
 	Get(key interface{}) interface{}
 	// Set sets the session value associated to the given key.
 	Set(key interface{}, val interface{})

--- a/sessions.go
+++ b/sessions.go
@@ -76,7 +76,13 @@ type session struct {
 }
 
 func (s *session) Get(key interface{}) interface{} {
-	return s.Session().Values[key]
+	v := s.Session().Values[key]
+
+	if v == nil {
+		return false
+	}
+
+	return v
 }
 
 func (s *session) Set(key interface{}, val interface{}) {
@@ -145,3 +151,4 @@ func (s *session) Written() bool {
 func Default(c *gin.Context) Session {
 	return c.MustGet(DefaultKey).(Session)
 }
+


### PR DESCRIPTION
I noticed that my code kept on panicking when session keys were not set; instead of doing a whole bunch of type checking pre request logic; I just have the `Get()` return `false` if it's `nil`. Keeps the code clean and kind of "pythonic".