### PR TITLE
Add NewRedisStoreWithDB/Pool

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"github.com/boj/redistore"
+	"github.com/garyburd/redigo/redis"
 	"github.com/gorilla/sessions"
 )
 
@@ -24,6 +25,29 @@ type RedisStore interface {
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStore(size int, network, address, password string, keyPairs ...[]byte) (RedisStore, error) {
 	store, err := redistore.NewRediStore(size, network, address, password, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+	return &redisStore{store}, nil
+}
+
+// NewRedisStoreWithDB - like NewRedisStore but accepts `DB` parameter to select
+// redis DB instead of using the default one ("0")
+//
+// Ref: https://godoc.org/github.com/boj/redistore#NewRediStoreWithDB
+func NewRedisStoreWithDB(size int, network, address, password, DB string, keyPairs ...[]byte) (RedisStore, error) {
+	store, err := redistore.NewRediStoreWithDB(size, network, address, password, DB, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+	return &redisStore{store}, nil
+}
+
+// NewRedisStoreWithPool instantiates a RediStore with a *redis.Pool passed in.
+//
+// Ref: https://godoc.org/github.com/boj/redistore#NewRediStoreWithPool
+func NewRedisStoreWithPool(pool *redis.Pool, keyPairs ...[]byte) (RedisStore, error) {
+	store, err := redistore.NewRediStoreWithPool(pool, keyPairs...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently `sessions.NewRedisStore()` only supports connecting to the default DB (`"0"`) and therefore it's quite useless under some situation (e.g. for the people who are using multiple DBs) due to lack of controllability.

This commit adds `sessions.NewRedisStoreWithDB()` and `sessions.NewRedisStoreWithPool()` which allows user take over the control about instantiating connection or whole `*redis.Pool`.