### PR TITLE
Allow for setting redis key prefix.

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -59,6 +59,11 @@ type store struct {
 	*redistore.RediStore
 }
 
+// SetKeyPrefix sets the key prefix in the redis database.
+func (c *store) SetKeyPrefix(prefix string) {
+	c.SetKeyPrefix(prefix)
+}
+
 func (c *store) Options(options sessions.Options) {
 	c.RediStore.Options = &gsessions.Options{
 		Path:     options.Path,


### PR DESCRIPTION
This is nice for Database organisation rather than having it all in the root key.