### PR TITLE
Expose the `*redistore.RediStore`

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -64,22 +64,23 @@ type store struct {
 //
 // Ref: https://godoc.org/github.com/boj/redistore#RediStore
 func GetRedisStore(s Store) (err error, rediStore *redistore.RediStore) {
-	if realStore, ok := s.(*store); !ok {
+	realStore, ok := s.(*store)
+	if !ok {
 		err = errors.New("unable to get the redis store: Store isn't *store")
-	} else {
-		rediStore = realStore.RediStore
 	}
 
+	rediStore = realStore.RediStore
 	return
 }
 
 // SetKeyPrefix sets the key prefix in the redis database.
 func SetKeyPrefix(s Store, prefix string) error {
-	if err, rediStore := GetRedisStore(s); err != nil {
+	err, rediStore := GetRedisStore(s)
+	if err != nil {
 		return err
-	} else {
-		rediStore.SetKeyPrefix(prefix)
 	}
+
+	rediStore.SetKeyPrefix(prefix)
 	return nil
 }
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -60,13 +60,16 @@ type store struct {
 	*redistore.RediStore
 }
 
-// GetRedisStore exposes the *redistore.RediStore
+// GetRedisStore get the actual woking stiore.
+//
+// Ref: https://godoc.org/github.com/boj/redistore#RediStore
 func GetRedisStore(s Store) (err error, rediStore *redistore.RediStore) {
-	if newStore, ok := s.(*redistore.RediStore); !ok {
-		err = errors.New("invalid store supplied")
+	if realStore, ok := s.(*store); !ok {
+		err = errors.New("unable to get the redis store: Store isn't *store")
 	} else {
-		rediStore = newStore
+		rediStore = realStore.RediStore
 	}
+
 	return
 }
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -60,10 +60,20 @@ type store struct {
 	*redistore.RediStore
 }
 
+// GetRedisStore exposes the *redistore.RediStore
+func GetRedisStore(s Store) (err error, rediStore *redistore.RediStore) {
+	if newStore, ok := s.(*redistore.RediStore); !ok {
+		err = errors.New("invalid store supplied")
+	} else {
+		rediStore = newStore
+	}
+	return
+}
+
 // SetKeyPrefix sets the key prefix in the redis database.
 func SetKeyPrefix(s Store, prefix string) error {
-	if rediStore, ok := s.(*store); !ok {
-		return errors.New("invalid store supplied")
+	if err, rediStore := GetRedisStore(s); err != nil {
+		return err
 	} else {
 		rediStore.SetKeyPrefix(prefix)
 	}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"errors"
 	"github.com/boj/redistore"
 	"github.com/gin-contrib/sessions"
 	"github.com/garyburd/redigo/redis"
@@ -60,8 +61,13 @@ type store struct {
 }
 
 // SetKeyPrefix sets the key prefix in the redis database.
-func (c *store) SetKeyPrefix(prefix string) {
-	c.SetKeyPrefix(prefix)
+func SetKeyPrefix(s Store, prefix string) error {
+	if rediStore, ok := s.(*store); !ok {
+		return errors.New("invalid store supplied")
+	} else {
+		rediStore.SetKeyPrefix(prefix)
+	}
+	return nil
 }
 
 func (c *store) Options(options sessions.Options) {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -59,6 +59,11 @@ type store struct {
 	*redistore.RediStore
 }
 
+// SetKeyPrefix sets the key prefix in the redis database.
+func (c *store) SetKeyPrefix(prefix string) {
+	c.SetKeyPrefix(prefix)
+}
+
 func (c *store) Options(options sessions.Options) {
 	c.RediStore.Options = &gsessions.Options{
 		Path:     options.Path,


### PR DESCRIPTION
This PR will require the reverting of #52 via #54.

Here we provide the `*redistore.RediStore`, and I think this should be done in all sessions that use other libraries to allow more advanced functionality.

This works and has been tested breifly