### PR TITLE
Change import redigo from garyburd to gomodule in redis/redis.go

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,9 +2,10 @@ package redis
 
 import (
 	"errors"
+
 	"github.com/boj/redistore"
 	"github.com/gin-contrib/sessions"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	gsessions "github.com/gorilla/sessions"
 )
 


### PR DESCRIPTION
I change the import to gomodule from garyburd, based on this error:

`redis/redis.go:52:42: cannot use pool (type *"github.com/garyburd/redigo/redis".Pool) as type *"github.com/gomodule/redigo/redis".Pool in argument to redistore.NewRediStoreWithPool`