### PR TITLE
fix GetRedisStore() panic

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -68,6 +68,7 @@ func GetRedisStore(s Store) (err error, rediStore *redistore.RediStore) {
 	realStore, ok := s.(*store)
 	if !ok {
 		err = errors.New("unable to get the redis store: Store isn't *store")
+		return
 	}
 
 	rediStore = realStore.RediStore

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -36,3 +36,13 @@ func TestRedis_SessionClear(t *testing.T) {
 func TestRedis_SessionOptions(t *testing.T) {
 	tester.Options(t, newRedisStore)
 }
+
+func TestGetRedisStore(t *testing.T) {
+	t.Run("unmatched type", func(t *testing.T) {
+		type store struct{ Store }
+		err, rediStore := GetRedisStore(store{})
+		if err == nil || rediStore != nil {
+			t.Fail()
+		}
+	})
+}


### PR DESCRIPTION
fix `GetRedisStore()` panic on unmatched store type