### PR TITLE
Session Cookie Options: add support for SameSite cookie.

### DIFF
--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -27,11 +27,5 @@ type store struct {
 }
 
 func (c *store) Options(options sessions.Options) {
-	c.CookieStore.Options = &gsessions.Options{
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	c.CookieStore.Options = options.ToGorillaOptions()
 }

--- a/memcached/memcached.go
+++ b/memcached/memcached.go
@@ -33,11 +33,5 @@ type store struct {
 }
 
 func (c *store) Options(options sessions.Options) {
-	c.MemcacheStore.Options = &gsessions.Options{
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	c.MemcacheStore.Options = options.ToGorillaOptions()
 }

--- a/memstore/memstore.go
+++ b/memstore/memstore.go
@@ -28,11 +28,5 @@ type store struct {
 }
 
 func (c *store) Options(options sessions.Options) {
-	c.MemStore.Options = &gsessions.Options{
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	c.MemStore.Options = options.ToGorillaOptions()
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -20,11 +20,5 @@ type store struct {
 }
 
 func (c *store) Options(options sessions.Options) {
-	c.MongoStore.Options = &gsessions.Options{
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	c.MongoStore.Options = options.ToGorillaOptions()
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -87,11 +87,5 @@ func SetKeyPrefix(s Store, prefix string) error {
 }
 
 func (c *store) Options(options sessions.Options) {
-	c.RediStore.Options = &gsessions.Options{
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	c.RediStore.Options = options.ToGorillaOptions()
 }

--- a/session_options_go1.10.go
+++ b/session_options_go1.10.go
@@ -1,0 +1,30 @@
+// +build !go1.11
+
+package sessions
+
+import (
+	gsessions "github.com/gorilla/sessions"
+)
+
+// Options stores configuration for a session or session store.
+// Fields are a subset of http.Cookie fields.
+type Options struct {
+	Path   string
+	Domain string
+	// MaxAge=0 means no 'Max-Age' attribute specified.
+	// MaxAge<0 means delete cookie now, equivalently 'Max-Age: 0'.
+	// MaxAge>0 means Max-Age attribute present and given in seconds.
+	MaxAge   int
+	Secure   bool
+	HttpOnly bool
+}
+
+func (options Options) ToGorillaOptions() *gsessions.Options {
+	return &gsessions.Options{
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+	}
+}

--- a/session_options_go1.11.go
+++ b/session_options_go1.11.go
@@ -1,0 +1,36 @@
+// +build go1.11
+
+package sessions
+
+import (
+	gsessions "github.com/gorilla/sessions"
+	"net/http"
+)
+
+// Options stores configuration for a session or session store.
+// Fields are a subset of http.Cookie fields.
+type Options struct {
+	Path   string
+	Domain string
+	// MaxAge=0 means no 'Max-Age' attribute specified.
+	// MaxAge<0 means delete cookie now, equivalently 'Max-Age: 0'.
+	// MaxAge>0 means Max-Age attribute present and given in seconds.
+	MaxAge   int
+	Secure   bool
+	HttpOnly bool
+	// rfc-draft to preventing CSRF: https://tools.ietf.org/html/draft-west-first-party-cookies-07
+	//   refer: https://godoc.org/net/http
+	//          https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/
+	SameSite http.SameSite
+}
+
+func (options Options) ToGorillaOptions() *gsessions.Options {
+	return &gsessions.Options{
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	}
+}

--- a/sessions.go
+++ b/sessions.go
@@ -19,19 +19,6 @@ type Store interface {
 	Options(Options)
 }
 
-// Options stores configuration for a session or session store.
-// Fields are a subset of http.Cookie fields.
-type Options struct {
-	Path   string
-	Domain string
-	// MaxAge=0 means no 'Max-Age' attribute specified.
-	// MaxAge<0 means delete cookie now, equivalently 'Max-Age: 0'.
-	// MaxAge>0 means Max-Age attribute present and given in seconds.
-	MaxAge   int
-	Secure   bool
-	HttpOnly bool
-}
-
 // Wraps thinly gorilla-session methods.
 // Session stores the values and optional configuration for a session.
 type Session interface {
@@ -118,13 +105,7 @@ func (s *session) Flashes(vars ...string) []interface{} {
 }
 
 func (s *session) Options(options Options) {
-	s.Session().Options = &sessions.Options{
-		Path:     options.Path,
-		Domain:   options.Domain,
-		MaxAge:   options.MaxAge,
-		Secure:   options.Secure,
-		HttpOnly: options.HttpOnly,
-	}
+	s.Session().Options = options.ToGorillaOptions()
 }
 
 func (s *session) Save() error {

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -208,6 +208,9 @@ func Options(t *testing.T, newStore storeFactory) {
 		session.Save()
 		c.String(200, ok)
 	})
+
+	test_option_same_site(t, r)
+
 	res1 := httptest.NewRecorder()
 	req1, _ := http.NewRequest("GET", "/domain", nil)
 	r.ServeHTTP(res1, req1)
@@ -225,6 +228,7 @@ func Options(t *testing.T, newStore storeFactory) {
 	if s[1] != " Domain=localhost" {
 		t.Error("Error writing domain with options:", s[1])
 	}
+
 }
 
 func Many(t *testing.T, newStore storeFactory) {

--- a/tester/tester_options_samesite_go1.10.go
+++ b/tester/tester_options_samesite_go1.10.go
@@ -1,0 +1,13 @@
+// +build !go1.11
+
+package tester
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func test_option_same_site(t *testing.T, r *gin.Engine) {
+	// not supported
+}

--- a/tester/tester_options_samesite_go1.11.go
+++ b/tester/tester_options_samesite_go1.11.go
@@ -1,0 +1,34 @@
+// +build go1.11
+package tester
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+)
+
+func test_option_same_site(t *testing.T, r *gin.Engine) {
+
+	r.GET("/sameSite", func(c *gin.Context) {
+		session := sessions.Default(c)
+		session.Set("key", ok)
+		session.Options(sessions.Options{
+			SameSite: http.SameSiteStrictMode,
+		})
+		session.Save()
+		c.String(200, ok)
+	})
+
+	res3 := httptest.NewRecorder()
+	req3, _ := http.NewRequest("GET", "/sameSite", nil)
+	r.ServeHTTP(res3, req3)
+
+	s := strings.Split(res3.Header().Get("Set-Cookie"), ";")
+	if s[1] != " SameSite=Strict" {
+		t.Error("Error writing samesite with options:", s[1])
+	}
+}


### PR DESCRIPTION
# SameSite cookie
Session Cookie Options: add support for cookie option `SameSite`.

SameSite cookie is used to prevent CSRF attack. It is supported by modern browsers and in RFC draft.

## Requires

This feature requires `golang  version 1.11+` to operate cookie.

`golang version 1.10` and below will remains untouched.


## REFS:
### The RFC draft
https://tools.ietf.org/html/draft-west-first-party-cookies-07

### Upstream Supports
[golang](https://godoc.org/net/http#SameSite) supports this option since version 1.11
[gorilla/sessions](https://godoc.org/github.com/gorilla/sessions#Options) supports this option.  when built on [golang v1.11+](https://github.com/gorilla/sessions/blob/master/options_go111.go)

### Supports of Browsers:
 https://caniuse.com/#feat=same-site-cookie-attribute

## About CSRF And SameSite
https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/

