### PR TITLE
Add PostgreSQL store (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Gin middleware for session management with multi-backend support:
 - [memcached](#memcached)
 - [MongoDB](#mongodb)
 - [memstore](#memstore)
+- [PostgreSQL](#postgresql)
 
 ## Usage
 
@@ -318,5 +319,49 @@ func main() {
     c.JSON(200, gin.H{"count": count})
   })
   r.Run(":8000")
+}
+```
+
+### PostgreSQL
+
+```go
+package main
+
+import (
+	"database/sql"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/postgres"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	db, err := sql.Open("postgres", "postgresql://username:password@localhost:5432/database")
+	if err != nil {
+		// handle err
+	}
+
+	store, err := postgres.NewStore(db, []byte("secret"))
+	if err != nil {
+		// handle err
+	}
+
+	r.Use(sessions.Sessions("mysession", store))
+
+	r.GET("/incr", func(c *gin.Context) {
+		session := sessions.Default(c)
+		var count int
+		v := session.Get("count")
+		if v == nil {
+			count = 0
+		} else {
+			count = v.(int)
+			count++
+		}
+		session.Set("count", count)
+		session.Save()
+		c.JSON(200, gin.H{"count": count})
+	})
+	r.Run(":8000")
 }
 ```

--- a/_example/postgres/main.go
+++ b/_example/postgres/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"database/sql"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/postgres"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	db, err := sql.Open("postgres", "postgresql://username:password@localhost:5432/database")
+	if err != nil {
+		// handle err
+	}
+
+	store, err := postgres.NewStore(db, []byte("secret"))
+	if err != nil {
+		// handle err
+	}
+
+	r.Use(sessions.Sessions("mysession", store))
+
+	r.GET("/incr", func(c *gin.Context) {
+		session := sessions.Default(c)
+		var count int
+		v := session.Get("count")
+		if v == nil {
+			count = 0
+		} else {
+			count = v.(int)
+			count++
+		}
+		session.Set("count", count)
+		session.Save()
+		c.JSON(200, gin.H{"count": count})
+	})
+	r.Run(":8000")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gin-contrib/sessions
 go 1.13
 
 require (
+	github.com/antonlindstrom/pgstore v0.0.0-20200229204646-b08ebf1105e0
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414f458e1
@@ -12,7 +13,9 @@ require (
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/kidstuff/mongostore v0.0.0-20181113001930-e650cd85ee4b
+	github.com/lib/pq v1.10.3 // indirect
 	github.com/memcachier/mc v2.0.1+incompatible
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/quasoft/memstore v0.0.0-20191010062613-2bce066d2b0b
 	github.com/stretchr/testify v1.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/antonlindstrom/pgstore v0.0.0-20200229204646-b08ebf1105e0 h1:grN4CYLduV1d9SYBSYrAMPVf57cxEa7KhenvwOXTktw=
+github.com/antonlindstrom/pgstore v0.0.0-20200229204646-b08ebf1105e0/go.mod h1:2Ti6VUHVxpC0VSmTZzEvpzysnaGAfGBOoMIz5ykPyyw=
 github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff h1:RmdPFa+slIr4SCBg4st/l/vZWVe9QJKMXGO60Bxbe04=
 github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff/go.mod h1:+RTT1BOk5P97fT2CiHkbFQwkK3mjsFAP6zCYV2aXtjw=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pOvUGt1D1lA5KjYhPBAN/3iWdP7xeFS9F0=
@@ -39,6 +41,8 @@ github.com/kidstuff/mongostore v0.0.0-20181113001930-e650cd85ee4b h1:TLCm7HR+P9H
 github.com/kidstuff/mongostore v0.0.0-20181113001930-e650cd85ee4b/go.mod h1:g2nVr8KZVXJSS97Jo8pJ0jgq29P6H7dG0oplUA86MQw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lib/pq v1.10.3 h1:v9QZf2Sn6AmjXtQeFpdoq/eaNtYP6IN+7lcrygsIAtg=
+github.com/lib/pq v1.10.3/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/memcachier/mc v2.0.1+incompatible h1:s8EDz0xrJLP8goitwZOoq1vA/sm0fPS4X3KAF0nyhWQ=
@@ -47,6 +51,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quasoft/memstore v0.0.0-20191010062613-2bce066d2b0b h1:aUNXCGgukb4gtY99imuIeoh8Vr0GSwAlYxPAhqZrpFc=

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -1,0 +1,30 @@
+package postgres
+
+import (
+	"database/sql"
+	"github.com/antonlindstrom/pgstore"
+	"github.com/gin-contrib/sessions"
+)
+
+type Store interface {
+	sessions.Store
+}
+
+type store struct {
+	*pgstore.PGStore
+}
+
+var _ Store = new(store)
+
+func NewStore(db *sql.DB, keyPairs ...[]byte) (Store, error) {
+	p, err := pgstore.NewPGStoreFromPool(db, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &store{p}, nil
+}
+
+func (s *store) Options(options sessions.Options) {
+	s.PGStore.Options = options.ToGorillaOptions()
+}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -1,0 +1,54 @@
+package postgres
+
+import (
+	"database/sql"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/tester"
+	"os"
+	"testing"
+)
+
+
+var newStore = func(_ *testing.T) sessions.Store {
+	// Env var in the format postgresql://username:password@localhost:5432/database?sslmode=disable required
+	dsn := os.Getenv("SESSIONS_POSTGRES_TEST")
+	if dsn == "" {
+		panic("database connection is required")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		panic(err)
+	}
+
+	store, err := NewStore(db, []byte("secret"))
+	if err != nil {
+		panic(err)
+	}
+
+	return store
+}
+
+func TestPostgres_SessionGetSet(t *testing.T) {
+	tester.GetSet(t, newStore)
+}
+
+func TestPostgres_SessionDeleteKey(t *testing.T) {
+	tester.DeleteKey(t, newStore)
+}
+
+func TestPostgres_SessionFlashes(t *testing.T) {
+	tester.Flashes(t, newStore)
+}
+
+func TestPostgres_SessionClear(t *testing.T) {
+	tester.Clear(t, newStore)
+}
+
+func TestPostgres_SessionOptions(t *testing.T) {
+	tester.Options(t, newStore)
+}
+
+func TestPostgres_SessionMany(t *testing.T) {
+	tester.Many(t, newStore)
+}


### PR DESCRIPTION
This PR adds support for a PostgreSQL store using the [antonlindstrom/pgstore](https://github.com/antonlindstrom/pgstore) Gorilla sessions store interface. A Postgres store example has been added and the README has been updated to reflect the sew store option.