### PR TITLE
Fix tests by providing a PostgreSQL database container

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           mongodb-version: 4.2
 
+      - name: Start PostgreSQL 14
+        uses: harmon758/postgresql-action@v1
+        with:
+          postgresql db: testdb
+          postgresql user: testuser
+          postgresql password: testpw
+          postgresql version: '14'
+
       - uses: niden/actions-memcached@v7
 
       - name: Set up Go ${{ matrix.go }}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -4,19 +4,13 @@ import (
 	"database/sql"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/tester"
-	"os"
 	"testing"
 )
 
+const postgresTestServer = "postgres://testuser:testpw@localhost:5432/testdb?sslmode=disable"
 
 var newStore = func(_ *testing.T) sessions.Store {
-	// Env var in the format postgresql://username:password@localhost:5432/database?sslmode=disable required
-	dsn := os.Getenv("SESSIONS_POSTGRES_TEST")
-	if dsn == "" {
-		panic("database connection is required")
-	}
-
-	db, err := sql.Open("postgres", dsn)
+	db, err := sql.Open("postgres", postgresTestServer)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR fixes the GitHub Actions test suite by providing a PostgreSQL database server to back the new PostgreSQL store functionality. The successful test suite using the new database container can be seen in action [here](https://github.com/andrewfrench/sessions/pull/1).