### PR TITLE
Mark session as written when updating options

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -111,6 +111,7 @@ func (s *session) Flashes(vars ...string) []interface{} {
 }
 
 func (s *session) Options(options Options) {
+	s.written = true
 	s.Session().Options = options.ToGorillaOptions()
 }
 


### PR DESCRIPTION
This PR changes the behavior of the Options() method. 

Currently, updating session options does set the `written` flag to `true`. This causes an issue when expiring/destroying a session, for example, because changes to session options will not be updated unless a key/value update has been made. If a developer wants to expire a session, they must set MaxAge to -1 and then make a trivial call to a method like Set() to ensure the options change will persist:

```go
// Destroy session
session := sessions.Default(c)
session.Options(sessions.Options{
    MaxAge: -1,
})
session.Set("deleteMe", true)
_ = session.Save()
```

Documentation from the session stores, like this snippet from the memstore source, indicate that setting MaxAge to -1 should immediately expire a session:

https://github.com/quasoft/memstore/blob/2bce066d2b0b885eab067015d658dfd8ec1880e0/memstore.go#L103

To make this library more usable, I've updated the `Options()` method to mark the session as written when session options have been updated, saving the additional call:

```go
// Destroy session
session := sessions.Default(c)
session.Option(sessions.Options{
    MaxAge: -1,
})
_ = session.Save()
```

Passing tests, including a case to test this behavior, can be found [here](https://github.com/andrewfrench/sessions/pull/2).