### PR TITLE
Add option to use multiple sessions with different stores

### DIFF
--- a/cookie/cookie_test.go
+++ b/cookie/cookie_test.go
@@ -35,3 +35,7 @@ func TestCookie_SessionOptions(t *testing.T) {
 func TestCookie_SessionMany(t *testing.T) {
 	tester.Many(t, newStore)
 }
+
+func TestCookie_SessionManyStores(t *testing.T) {
+	tester.ManyStores(t, newStore)
+}

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -41,6 +41,10 @@ func TestMemcached_SessionMany(t *testing.T) {
 	tester.Many(t, newStore)
 }
 
+func TestMemcached_SessionManyStores(t *testing.T) {
+	tester.ManyStores(t, newStore)
+}
+
 var newBinaryStore = func(_ *testing.T) sessions.Store {
 	store := NewMemcacheStore(
 		mc.NewMC(memcachedTestServer, "", ""), "", []byte("secret"))
@@ -69,4 +73,8 @@ func TestBinaryMemcached_SessionOptions(t *testing.T) {
 
 func TestBinaryMemcached_SessionMany(t *testing.T) {
 	tester.Many(t, newBinaryStore)
+}
+
+func TestBinaryMemcached_SessionManyStpres(t *testing.T) {
+	tester.ManyStores(t, newBinaryStore)
 }

--- a/memstore/memstore_test.go
+++ b/memstore/memstore_test.go
@@ -35,3 +35,7 @@ func TestCookie_SessionOptions(t *testing.T) {
 func TestCookie_SessionMany(t *testing.T) {
 	tester.Many(t, newStore)
 }
+
+func TestCookie_SessionManyStores(t *testing.T) {
+	tester.ManyStores(t, newStore)
+}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -43,3 +43,7 @@ func TestMongo_SessionOptions(t *testing.T) {
 func TestMongo_SessionMany(t *testing.T) {
 	tester.Many(t, newStore)
 }
+
+func TestMongo_SessionManyStores(t *testing.T) {
+	tester.ManyStores(t, newStore)
+}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -46,3 +46,7 @@ func TestPostgres_SessionOptions(t *testing.T) {
 func TestPostgres_SessionMany(t *testing.T) {
 	tester.Many(t, newStore)
 }
+
+func TestPostgres_SessionManyStores(t *testing.T) {
+	tester.ManyStores(t, newStore)
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -41,6 +41,10 @@ func TestRedis_SessionMany(t *testing.T) {
 	tester.Many(t, newRedisStore)
 }
 
+func TestRedis_SessionManyStores(t *testing.T) {
+	tester.ManyStores(t, newRedisStore)
+}
+
 func TestGetRedisStore(t *testing.T) {
 	t.Run("unmatched type", func(t *testing.T) {
 		type store struct{ Store }


### PR DESCRIPTION
Based off of discussions in: https://github.com/gin-contrib/sessions/issues/124

The basic premise:

Sometimes it is helpful to have different session stores for sessions that have a different purpose.

For example:
- CSRF tokens stored in cookies
- User sessions stored in a server-side technology

Additionally, you may also just want to use the same technology but with different settings. For example, one store might have a `MaxAge` of 10 minutes while another has a `MaxAge` of 30 days.