### PR TITLE
Add syntax highlight for mongo-driver example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ func main() {
 ```
 
 #### mongo-driver
-```
+```go
 package main
 
 import (


### PR DESCRIPTION
Why every example has syntax highlight except this one?
