### PR TITLE
set code block type to Go for mongo-go-driver example

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ func main() {
 ```
 
 #### mongo-driver
-```
+```go
 package main
 
 import (


### PR DESCRIPTION
Looks like the language type for the code block example for mongo-go-driver was not set. This PR fixes that.