### PR TITLE
Added guard to split not to get out of bounds exception when testing

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -134,7 +134,6 @@ func (s *session) Session() *sessions.Session {
 			slog.Error(errorFormat,
 				"err", err,
 			)
-			return nil
 		}
 	}
 	return s.session

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -249,16 +249,23 @@ func Options(t *testing.T, newStore storeFactory) {
 	r.ServeHTTP(res5, req5)
 
 	for _, c := range res1.Header().Values("Set-Cookie") {
-		s := strings.Split(c, ";")
-		if s[1] != " Path=/foo/bar/bat" {
-			t.Error("Error writing path with options:", s[1])
+		s := strings.Split(c, "; ")
+		if len(s) < 2 {
+			t.Fatal("No Path=/foo/bar/batt found in options")
+		}
+		if s[1] != "Path=/foo/bar/bat" {
+			t.Fatal("Error writing path with options:", s[1])
 		}
 	}
 
 	for _, c := range res2.Header().Values("Set-Cookie") {
-		s := strings.Split(c, ";")
-		if s[1] != " Domain=localhost" {
-			t.Error("Error writing domain with options:", s[1])
+		s := strings.Split(c, "; ")
+		if len(s) < 2 {
+			t.Fatal("No Domain=localhost found in options")
+		}
+
+		if s[1] != "Domain=localhost" {
+			t.Fatal("Error writing domain with options:", s[1])
 		}
 	}
 }

--- a/tester/tester_options_samesite_go1.11.go
+++ b/tester/tester_options_samesite_go1.11.go
@@ -29,8 +29,11 @@ func testOptionSameSitego(t *testing.T, r *gin.Engine) {
 	req3, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/sameSite", nil)
 	r.ServeHTTP(res3, req3)
 
-	s := strings.Split(res3.Header().Get("Set-Cookie"), ";")
-	if s[1] != " SameSite=Strict" {
-		t.Error("Error writing samesite with options:", s[1])
+	s := strings.Split(res3.Header().Get("Set-Cookie"), "; ")
+	if len(s) < 2 {
+		t.Fatal("No SameSite=Strict found in options")
+	}
+	if s[1] != "SameSite=Strict" {
+		t.Fatal("Error writing samesite with options:", s[1])
 	}
 }


### PR DESCRIPTION
In the current test code we're accessing the splitted slice without checking if split returned a slice long enough.

```go
    s := strings.Split(c, ";")
    if s[1] != " Path=/foo/bar/bat" {
	t.Error("Error writing path with options:", s[1])
    }
```

This patch checks the len of s is enough to access s[1]