### PR TITLE
Reverting Session() returning nil if session does not exist (issue #287)

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -134,7 +134,6 @@ func (s *session) Session() *sessions.Session {
 			slog.Error(errorFormat,
 				"err", err,
 			)
-			return nil
 		}
 	}
 	return s.session


### PR DESCRIPTION
As reported by @alan-anzenna this reverts Issue #287.

**Description:**

```s.store.Get()``` returns a new session when returning an error for gorilla session's ```CookieStore.```
```
// Get returns a session for the given name after adding it to the registry.
//
// It returns a new session if the sessions doesn't exist. Access IsNew on
// the session to check if it is an existing session or a new one.
//
// It returns a new session and an error if the session exists but could
// not be decoded.
```
In 1.0.2, Session() would use this new session. In 1.0.3, Session() returns nil.

This behavior was changed [here](https://github.com/gin-contrib/sessions/commit/f361a4d944dc186a7768f331ad8b0b424239d80a#diff-69b244e088f00af3a4cf3ecc7f333c380440de0cf6c721c60f2f6715d7371f2fR137).

Most of the callers in sessions.go (such as ID()) are not written to handle Session() returning nil.